### PR TITLE
Updated .env.sample

### DIFF
--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -1,1 +1,1 @@
-React_App_Backend_EndPoint = http://localhost:5000 OR <YOUR HOSTED BACKEND LINK>
+VITE_Backend_EndPoint = http://localhost:5000 OR <YOUR HOSTED BACKEND LINK>


### PR DESCRIPTION
VITE_Backend_EndPoint is the env variable used in the code but in sample env it was initialized as React_App_Backend_EndPoint, which resulted in failed API Calls to backend